### PR TITLE
Proxy requests to lobby server

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,9 +36,13 @@ module.exports = (env) => {
             'react-hot-loader/patch',
             'webpack/hot/only-dev-server'] : []).concat(['./index.jsx', './less/site.less', 'babel-polyfill']) },
         devServer: {
-            contentBase: './dist',
+            contentBase: './assets',
             hot: true,
-            host: process.env.HOST || 'localhost'
+            host: process.env.HOST || 'localhost',
+            proxy: [{
+                context: ['/**', '!/img/**', '!/fonts/**', '!/sound/**'],
+                target: 'http://localhost:4000'
+            }]
         },
         devtool: isDevBuild ? 'inline-source-map' : 'source-map',
         module: {


### PR DESCRIPTION
Allows webpack-dev-server to be used directly when developing by
proxying all non-asset requests to the lobby server. This allows hot
reload to actually work.