### PR TITLE
Various styling fixes

### DIFF
--- a/Components/GameBoard/GameBoard.jsx
+++ b/Components/GameBoard/GameBoard.jsx
@@ -5,7 +5,6 @@ import $ from 'jquery';
 import { toastr } from 'react-redux-toastr';
 import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
-import { CSSTransitionGroup } from 'react-transition-group';
 
 import PlayerStats from './PlayerStats';
 import PlayerRow from './PlayerRow';
@@ -459,17 +458,16 @@ export class GameBoard extends React.Component {
                     <CardZoom imageUrl={ this.props.cardToZoom ? '/img/cards/' + this.props.cardToZoom.code + '.png' : '' }
                         orientation={ this.props.cardToZoom ? this.props.cardToZoom.type === 'plot' ? 'horizontal' : 'vertical' : 'vertical' }
                         show={ !!this.props.cardToZoom } cardName={ this.props.cardToZoom ? this.props.cardToZoom.name : null } />
-                    <div className='right-side'>
+                    { this.state.showMessages && <div className='right-side'>
                         <div className='gamechat'>
-                            <CSSTransitionGroup className='chatwrapper' transitionName='gamechat' transitionEnterTimeout={ 500 } transitionLeaveTimeout={ 500 }>
-                                { this.state.showMessages && <GameChat key='gamechat'
-                                    messages={ this.props.currentGame.messages }
-                                    onCardMouseOut={ this.onMouseOut }
-                                    onCardMouseOver={ this.onMouseOver }
-                                    onSendChat={ this.sendChatMessage } /> }
-                            </CSSTransitionGroup>
+                            <GameChat key='gamechat'
+                                messages={ this.props.currentGame.messages }
+                                onCardMouseOut={ this.onMouseOut }
+                                onCardMouseOver={ this.onMouseOver }
+                                onSendChat={ this.sendChatMessage } />
                         </div>
                     </div>
+                    }
                 </div>
                 <div className='player-stats-row'>
                     <PlayerStats { ...boundActionCreators } stats={ thisPlayer.stats } showControls={ !this.state.spectating } user={ thisPlayer.user }

--- a/Components/GameBoard/PopupDefaults.js
+++ b/Components/GameBoard/PopupDefaults.js
@@ -1,47 +1,46 @@
 export default {
     'plot deck-bottom': {
-        left: '90px',
-        bottom: '95px'
+        left: '100px',
+        bottom: '155px'
     },
     'revealed plots-bottom': {
-        left: '90px',
-        bottom: '25px'
+        left: '100px',
+        bottom: '230px'
     },
     'revealed plots-top': {
-        left: '95px',
-        top: '25px'
+        left: '100px',
+        top: '155px'
     },
     'draw deck-bottom': {
-        left: '0',
-        bottom: '95px'
+        bottom: '140px'
     },
     'discard pile-bottom': {
-        bottom: '95px'
+        bottom: '155px'
     },
     'discard pile-top': {
-        top: '95px'
+        top: '185px'
     },
     'dead pile-bottom': {
-        bottom: '75px'
+        bottom: '140px'
     },
     'dead pile-top': {
-        top: '75px'
+        top: '165px'
     },
     'out of game-top': {
-        top: '75px',
+        top: '155px',
         left: '20px'
     },
     'out of game-bottom': {
-        bottom: '75px',
+        bottom: '155px',
         right: '0'
     },
     'conclave-bottom': {
-        bottom: '95px'
+        bottom: '155px'
     },
     'shadows-bottom': {
-        bottom: '95px'
+        bottom: '155px'
     },
     'shadows-top': {
-        top: '95px'
+        top: '155px'
     }
 };

--- a/less/gameboard.less
+++ b/less/gameboard.less
@@ -111,6 +111,7 @@
 .popup {
   z-index: @layer-card-menu;
   background-color: rgba(0, 0, 0, 0.85);
+  position: fixed;
 
   a {
     display: inline-block;
@@ -314,8 +315,6 @@
 
 .additional-cards {
   .popup {
-    position: absolute;
-
     .inner {
       .calculate-tiled-card-prop(min-height, 2, width);
       .calculate-tiled-card-prop(min-width, 2, height, @scrollbar-width);
@@ -327,7 +326,6 @@
   margin: 5px;
 
   .popup {
-    position: absolute;
     min-height: 92px;
     min-width: 168px;
 
@@ -340,7 +338,6 @@
 
 .shadows {
   .popup {
-    position: absolute;
     min-height: 146px;
 
     .inner {
@@ -352,7 +349,6 @@
 
 .discard {
   .popup {
-    position: absolute;
     min-height: 146px;
 
     .inner {
@@ -364,8 +360,6 @@
 
 .dead {
   .popup {
-    position: absolute;
-
     .inner {
       .calculate-tiled-card-prop(min-height, 1, height);
       .calculate-tiled-card-prop(width, 5, width, @scrollbar-width);
@@ -381,18 +375,10 @@
 
 .draw {
   .popup {
-    position: absolute;
-
     .inner {
       .calculate-tiled-card-prop(min-height, 1, height);
       .calculate-tiled-card-prop(width, 7, width, @scrollbar-width);
     }
-  }
-}
-
-.agenda {
-  .popup {
-    position: absolute;
   }
 }
 
@@ -565,6 +551,8 @@ span.down-arrow {
 
 .player-home-row {
   display: flex;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 .player-home-row-container {
@@ -725,7 +713,7 @@ span.down-arrow {
 
 .gamechat-enter.gamechat-enter-active {
   position: absolute;
-  top: 0; 
+  top: 0;
   right: 0;
   width: 100%;
   transition: top 500ms ease-in-out;


### PR DESCRIPTION
Collapse the whole right side frame when toggling messages - this allows the board to fill the space when it's hidden
Add a scrollbar to the player row in case the screen is too narrow
change the popups to position: fixed