### PR TITLE
Fix detection of Banner agendas for Alliance

### DIFF
--- a/reducers/cards.js
+++ b/reducers/cards.js
@@ -47,7 +47,7 @@ export default function(state = { decks: [] }, action) {
             }
 
             var banners = Object.values(agendas).filter(card => {
-                return card.label.startsWith('Banner of the');
+                return card.traits.includes('Banner');
             });
 
             newState = Object.assign({}, state, {


### PR DESCRIPTION
Previously we were looking for agendas that started with "Banner of
the". The new Banner agenda "Trading with Qohor" was thus not being
listed as a valid agenda for Alliance.