### PR TITLE
Initial UI for cards placed underneath (Meereen)

### DIFF
--- a/Components/GameBoard/Card.jsx
+++ b/Components/GameBoard/Card.jsx
@@ -8,6 +8,8 @@ import CardMenu from './CardMenu';
 import CardCounters from './CardCounters';
 import { ItemTypes } from '../../constants';
 
+import SquishableCardPanel from './SquishableCardPanel';
+
 const cardSource = {
     beginDrag(props) {
         return {
@@ -184,6 +186,29 @@ class InnerCard extends React.Component {
         return dupes;
     }
 
+    renderUnderneathCards() {
+        // TODO: Right now it is assumed that all cards in the childCards array
+        // are being placed underneath the current card. In the future there may
+        // be other types of cards in this array and it should be filtered.
+        let underneathCards = this.props.card.childCards;
+        if(!underneathCards || underneathCards.length === 0) {
+            return;
+        }
+
+        let maxCards = 1 + (underneathCards.length - 1) / 6;
+
+        return (
+            <SquishableCardPanel
+                cardSize={ this.props.size }
+                cards={ underneathCards }
+                className='underneath'
+                maxCards={ maxCards }
+                onCardClick={ this.props.onClick }
+                onMouseOut={ this.props.onMouseOut }
+                onMouseOver={ this.props.onMouseOver }
+                source='underneath' />);
+    }
+
     getCardOrder() {
         if(!this.props.card.order) {
             return null;
@@ -336,6 +361,7 @@ class InnerCard extends React.Component {
                     { this.getCard() }
                     { this.getDupes() }
                     { this.getAttachments() }
+                    { this.renderUnderneathCards() }
                 </div>);
         }
 
@@ -349,6 +375,7 @@ InnerCard.propTypes = {
         attached: PropTypes.bool,
         attachments: PropTypes.array,
         baseStrength: PropTypes.number,
+        childCards: PropTypes.array,
         code: PropTypes.string,
         controlled: PropTypes.bool,
         dupes: PropTypes.array,
@@ -385,7 +412,7 @@ InnerCard.propTypes = {
     orientation: PropTypes.oneOf(['horizontal', 'kneeled', 'vertical']),
     size: PropTypes.string,
     source: PropTypes.oneOf(['hand', 'discard pile', 'play area', 'dead pile', 'draw deck', 'plot deck', 'revealed plots', 'selected plot', 'attachment', 'agenda', 'faction',
-        'additional', 'conclave', 'shadows', 'full deck', 'rookery']).isRequired,
+        'additional', 'conclave', 'shadows', 'full deck', 'rookery', 'underneath']).isRequired,
     style: PropTypes.object,
     wrapped: PropTypes.bool
 };

--- a/Components/GameBoard/PlayerRow.jsx
+++ b/Components/GameBoard/PlayerRow.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import CardPile from './CardPile';
-import PlayerHand from './PlayerHand';
+import SquishableCardPanel from './SquishableCardPanel';
 import Droppable from './Droppable';
 
 class PlayerRow extends React.Component {
@@ -176,9 +176,9 @@ class PlayerRow extends React.Component {
             size: this.props.cardSize
         };
 
-        let hand = (<PlayerHand
+        let hand = (<SquishableCardPanel
             cards={ this.props.hand }
-            className='hand'
+            className='panel hand'
             isMe={ this.props.isMe }
             username={ this.props.username }
             maxCards={ 5 }
@@ -200,10 +200,10 @@ class PlayerRow extends React.Component {
         let deadPile = (<CardPile className='dead' title='Dead' source='dead pile' cards={ this.props.deadPile }
             orientation='kneeled'
             { ...cardPileProps } />);
-        let shadows = (<PlayerHand
+        let shadows = (<SquishableCardPanel
             cards={ this.props.shadows }
             cardSize={ this.props.cardSize }
-            className='shadows'
+            className='panel shadows'
             isMe={ this.props.isMe }
             maxCards={ 2 }
             onCardClick={ this.props.onCardClick }

--- a/Components/GameBoard/SquishableCardPanel.jsx
+++ b/Components/GameBoard/SquishableCardPanel.jsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 import Card from './Card';
 
-class PlayerHand extends React.Component {
+class SquishableCardPanel extends React.Component {
     disableMouseOver(revealWhenHiddenTo) {
         if(this.props.spectating && this.props.showHand) {
             return false;
@@ -93,7 +93,7 @@ class PlayerHand extends React.Component {
         let needsSquish = this.props.cards && this.props.cards.length > maxCards;
         let cards = this.getCards(needsSquish, maxCards);
 
-        let className = classNames('panel', 'squishable-card-panel', this.props.className, {
+        let className = classNames('squishable-card-panel', this.props.className, {
             [this.props.cardSize]: this.props.cardSize !== 'normal',
             'squish': needsSquish
         });
@@ -105,17 +105,19 @@ class PlayerHand extends React.Component {
 
         return (
             <div className={ className } style={ style }>
-                <div className='panel-header'>
-                    { `${this.props.title} (${cards.length})` }
-                </div>
+                { this.props.title &&
+                    <div className='panel-header'>
+                        { `${this.props.title} (${cards.length})` }
+                    </div>
+                }
                 { cards }
             </div>
         );
     }
 }
 
-PlayerHand.displayName = 'PlayerHand';
-PlayerHand.propTypes = {
+SquishableCardPanel.displayName = 'SquishableCardPanel';
+SquishableCardPanel.propTypes = {
     cardSize: PropTypes.string,
     cards: PropTypes.array,
     className: PropTypes.string,
@@ -131,4 +133,4 @@ PlayerHand.propTypes = {
     username: PropTypes.string
 };
 
-export default PlayerHand;
+export default SquishableCardPanel;

--- a/less/cards.less
+++ b/less/cards.less
@@ -819,3 +819,22 @@
   height: 100%;
   z-index: @layer-top;
 }
+
+.underneath {
+  margin-left: 0;
+  margin-top: -@card-height / 2;
+  position: relative;
+  z-index: @layer-cards + 1;
+
+  &.small {
+    margin-top: -@card-sm-height / 2;
+  }
+
+  &.large {
+    margin-top: -@card-lg-height / 2;
+  }
+
+  &.x-large {
+    margin-top: -@card-xl-height / 2;
+  }
+}


### PR DESCRIPTION
Currently this places the cards on top of the parent card and expands leftward. This will obscure attachments on the card but more UI help is needed to make it look good to place the cards underneath the parent.

![screen shot 2018-07-03 at 11 28 37 am](https://user-images.githubusercontent.com/145077/42238176-d9172306-7eb4-11e8-8215-05b835f54958.png)
