### PR TITLE
Show in-hand / shadow cards based on facedown prop

### DIFF
--- a/Components/GameBoard/GameBoard.jsx
+++ b/Components/GameBoard/GameBoard.jsx
@@ -329,7 +329,6 @@ export class GameBoard extends React.Component {
                         outOfGamePile={ otherPlayer.cardPiles.outOfGamePile }
                         username={ this.props.user.username }
                         shadows={ otherPlayer.cardPiles.shadows }
-                        showHand={ this.props.currentGame.showHand }
                         spectating={ this.state.spectating }
                         title={ otherPlayer.title }
                         side='top'
@@ -395,7 +394,6 @@ export class GameBoard extends React.Component {
                         discardPile={ thisPlayer.cardPiles.discardPile }
                         deadPile={ thisPlayer.cardPiles.deadPile }
                         shadows={ thisPlayer.cardPiles.shadows }
-                        showHand={ this.props.currentGame.showHand }
                         spectating={ this.state.spectating }
                         title={ thisPlayer.title }
                         onMenuItemClick={ this.onMenuItemClick }

--- a/Components/GameBoard/PlayerRow.jsx
+++ b/Components/GameBoard/PlayerRow.jsx
@@ -185,9 +185,7 @@ class PlayerRow extends React.Component {
             onCardClick={ this.props.onCardClick }
             onMouseOut={ this.props.onMouseOut }
             onMouseOver={ this.props.onMouseOver }
-            showHand={ this.props.showHand }
             source='hand'
-            spectating={ this.props.spectating }
             title='Hand'
             cardSize={ this.props.cardSize } />);
         let drawDeck = (<CardPile className='draw' title='Draw' source='draw deck' cards={ this.props.drawDeck }
@@ -209,9 +207,7 @@ class PlayerRow extends React.Component {
             onCardClick={ this.props.onCardClick }
             onMouseOut={ this.props.onMouseOut }
             onMouseOver={ this.props.onMouseOver }
-            showHand={ this.props.showHand }
             source='shadows'
-            spectating={ this.props.spectating }
             title='Shadows'
             username={ this.props.username } />);
 
@@ -261,7 +257,6 @@ PlayerRow.propTypes = {
     power: PropTypes.number,
     shadows: PropTypes.array,
     showDrawDeck: PropTypes.bool,
-    showHand: PropTypes.bool,
     side: PropTypes.oneOf(['top', 'bottom']),
     spectating: PropTypes.bool,
     title: PropTypes.object,

--- a/Components/GameBoard/SquishableCardPanel.jsx
+++ b/Components/GameBoard/SquishableCardPanel.jsx
@@ -5,12 +5,8 @@ import classNames from 'classnames';
 import Card from './Card';
 
 class SquishableCardPanel extends React.Component {
-    disableMouseOver(revealWhenHiddenTo) {
-        if(this.props.spectating && this.props.showHand) {
-            return false;
-        }
-
-        if(revealWhenHiddenTo === this.props.username) {
+    disableMouseOver(card) {
+        if(!card.facedown) {
             return false;
         }
 
@@ -31,7 +27,7 @@ class SquishableCardPanel extends React.Component {
         let offset = overflow / (handLength - 1);
 
         if(!this.props.isMe) {
-            cards = [...this.props.cards].sort((a, b) => a.revealWhenHiddenTo - b.revealWhenHiddenTo);
+            cards = [...this.props.cards].sort((a, b) => a.facedown && !b.facedown ? -1 : 1);
         }
 
         let hand = cards.map(card => {
@@ -46,7 +42,7 @@ class SquishableCardPanel extends React.Component {
 
             return (<Card key={ card.uuid }
                 card={ card }
-                disableMouseOver={ this.disableMouseOver(card.revealWhenHiddenTo) }
+                disableMouseOver={ this.disableMouseOver(card) }
                 onClick={ this.props.onCardClick }
                 onMouseOver={ this.props.onMouseOver }
                 onMouseOut={ this.props.onMouseOut }
@@ -126,9 +122,7 @@ SquishableCardPanel.propTypes = {
     onCardClick: PropTypes.func,
     onMouseOut: PropTypes.func,
     onMouseOver: PropTypes.func,
-    showHand: PropTypes.bool,
     source: PropTypes.string,
-    spectating: PropTypes.bool,
     title: PropTypes.string,
     username: PropTypes.string
 };


### PR DESCRIPTION
Previously, the `revealWhenHiddenTo` and `showHand` properties were
being used to control whether to allow card hover for cards in hand.
However, an easier check is whether the card data sent from the server
is facedown or not - the full data for the card is sent non-facedown in
both cases. Thus, these properties don't need to be used in the client.

Additionally, the sorting for partially revealed hands was broken. This
fixes it by sorting all faceup cards after facedown cards.