### PR TITLE
Remove card sorting based on visibility

### DIFF
--- a/Components/GameBoard/SquishableCardPanel.jsx
+++ b/Components/GameBoard/SquishableCardPanel.jsx
@@ -26,10 +26,6 @@ class SquishableCardPanel extends React.Component {
         let overflow = requiredWidth - overallDimensions.width;
         let offset = overflow / (handLength - 1);
 
-        if(!this.props.isMe) {
-            cards = [...this.props.cards].sort((a, b) => a.facedown && !b.facedown ? -1 : 1);
-        }
-
         let hand = cards.map(card => {
             let left = (cardWidth - offset) * cardIndex++;
 


### PR DESCRIPTION
Hired Assassin looks at facedown shadows cards and shadows cards are not allowed to be rearranged.