### PR TITLE
Make grouping cards by visibility optional

### DIFF
--- a/Components/GameBoard/PlayerRow.jsx
+++ b/Components/GameBoard/PlayerRow.jsx
@@ -179,6 +179,7 @@ class PlayerRow extends React.Component {
         let hand = (<SquishableCardPanel
             cards={ this.props.hand }
             className='panel hand'
+            groupVisibleCards
             isMe={ this.props.isMe }
             username={ this.props.username }
             maxCards={ 5 }

--- a/Components/GameBoard/SquishableCardPanel.jsx
+++ b/Components/GameBoard/SquishableCardPanel.jsx
@@ -26,7 +26,7 @@ class SquishableCardPanel extends React.Component {
         let overflow = requiredWidth - overallDimensions.width;
         let offset = overflow / (handLength - 1);
 
-        if(!this.props.isMe) {
+        if(!this.props.isMe && this.props.groupVisibleCards) {
             cards = [...this.props.cards].sort((a, b) => a.facedown && !b.facedown ? -1 : 1);
         }
 
@@ -117,6 +117,7 @@ SquishableCardPanel.propTypes = {
     cardSize: PropTypes.string,
     cards: PropTypes.array,
     className: PropTypes.string,
+    groupVisibleCards: PropTypes.bool,
     isMe: PropTypes.bool,
     maxCards: PropTypes.number,
     onCardClick: PropTypes.func,


### PR DESCRIPTION
For in hand cards, we want to group visible cards together so that the
order of cards in hand isn't revealed. However, for cards in shadows,
the order needs to be maintained. This can now be controlled by the
`groupVisibleCards` property on the `SquishableCardPanel` component.