### PR TITLE
Allow search prompts to use the draw deck

### DIFF
--- a/Components/GameBoard/CardPile.jsx
+++ b/Components/GameBoard/CardPile.jsx
@@ -26,9 +26,21 @@ class CardPile extends React.Component {
         let didHaveSelectableCard = this.props.cards && this.props.cards.some(card => card.selectable);
 
         if(!didHaveSelectableCard && hasNewSelectableCard) {
-            this.setState({ showPopup: true });
+            this.updatePopupVisibility(true);
         } else if(didHaveSelectableCard && !hasNewSelectableCard) {
-            this.setState({ showPopup: false });
+            this.updatePopupVisibility(false);
+        }
+    }
+
+    togglePopup() {
+        this.updatePopupVisibility(!this.state.showPopup);
+    }
+
+    updatePopupVisibility(value) {
+        this.setState({ showPopup: value });
+
+        if(this.props.onPopupChange) {
+            this.props.onPopupChange({ source: this.props.source, visible: value });
         }
     }
 
@@ -41,33 +53,33 @@ class CardPile extends React.Component {
         }
 
         if(!this.props.disablePopup) {
-            this.setState({ showPopup: !this.state.showPopup });
+            this.togglePopup();
         }
     }
 
     onMenuItemClick(menuItem) {
         if(menuItem.showPopup) {
-            this.setState({ showPopup: !this.state.showPopup });
+            this.togglePopup();
         }
 
-        menuItem.handler();
+        if(menuItem.handler) {
+            menuItem.handler();
+        }
     }
 
     onCloseClick(event) {
         event.preventDefault();
         event.stopPropagation();
 
-        this.setState({ showPopup: !this.state.showPopup });
-
-        if(this.props.onCloseClick) {
-            this.props.onCloseClick();
-        }
+        this.togglePopup();
     }
 
     onPopupMenuItemClick(menuItem) {
-        menuItem.handler();
+        if(menuItem.handler) {
+            menuItem.handler();
+        }
 
-        this.setState({ showPopup: !this.state.showPopup });
+        this.togglePopup();
     }
 
     onTopCardClick() {
@@ -84,7 +96,7 @@ class CardPile extends React.Component {
             return;
         }
 
-        this.setState({ showPopup: !this.state.showPopup });
+        this.togglePopup();
     }
 
     get isTopCardSelectable() {
@@ -97,7 +109,7 @@ class CardPile extends React.Component {
 
     onCardClick(card) {
         if(this.props.closeOnClick) {
-            this.setState({ showPopup: false });
+            this.updatePopupVisibility(false);
         }
 
         if(this.props.onCardClick) {
@@ -226,11 +238,11 @@ CardPile.propTypes = {
     hiddenTopCard: PropTypes.bool,
     menu: PropTypes.array,
     onCardClick: PropTypes.func,
-    onCloseClick: PropTypes.func,
     onDragDrop: PropTypes.func,
     onMenuItemClick: PropTypes.func,
     onMouseOut: PropTypes.func,
     onMouseOver: PropTypes.func,
+    onPopupChange: PropTypes.func,
     onTouchMove: PropTypes.func,
     orientation: PropTypes.string,
     popupLocation: PropTypes.string,

--- a/Components/GameBoard/CardPile.jsx
+++ b/Components/GameBoard/CardPile.jsx
@@ -12,7 +12,7 @@ class CardPile extends React.Component {
         super(props);
 
         this.state = {
-            showPopup: false,
+            showPopup: !!props.cards && props.cards.some(card => card.selectable),
             showMenu: false
         };
 

--- a/Components/GameBoard/DrawDeck.jsx
+++ b/Components/GameBoard/DrawDeck.jsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import CardPile from './CardPile';
+import Droppable from './Droppable';
+
+class DrawDeck extends React.Component {
+    constructor() {
+        super();
+
+        this.handlePileClick = this.handlePileClick.bind(this);
+        this.handleShuffleClick = this.handleShuffleClick.bind(this);
+        this.handleShowDeckClick = this.handleShowDeckClick.bind(this);
+        this.handleCloseClick = this.handleCloseClick.bind(this);
+        this.handleCloseAndShuffleClick = this.handleCloseAndShuffleClick.bind(this);
+
+        this.state = {
+            showDrawMenu: false
+        };
+    }
+
+    handleCloseClick() {
+        if(this.props.onDrawClick) {
+            this.props.onDrawClick();
+        }
+    }
+
+    handleCloseAndShuffleClick() {
+        if(this.props.onDrawClick) {
+            this.props.onDrawClick();
+        }
+
+        if(this.props.onShuffleClick) {
+            this.props.onShuffleClick();
+        }
+    }
+
+    handlePileClick() {
+        this.setState({ showDrawMenu: !this.state.showDrawMenu });
+    }
+
+    handleShuffleClick() {
+        if(this.props.onShuffleClick) {
+            this.props.onShuffleClick();
+        }
+    }
+
+    handleShowDeckClick() {
+        if(this.props.onDrawClick) {
+            this.props.onDrawClick();
+        }
+    }
+
+    renderDroppablePile(source, child) {
+        return this.props.isMe ? <Droppable onDragDrop={ this.props.onDragDrop } source={ source }>{ child }</Droppable> : child;
+    }
+
+    render() {
+        let drawDeckMenu = this.props.isMe && !this.props.spectating ? [
+            { text: 'Show', handler: this.handleShowDeckClick, showPopup: true },
+            { text: 'Shuffle', handler: this.handleShuffleClick }
+        ] : null;
+
+        let drawDeckPopupMenu = [
+            { text: 'Close and Shuffle', handler: this.handleCloseAndShuffleClick }
+        ];
+
+        let drawDeck = (<CardPile className='draw'
+            cardCount={ this.props.cardCount }
+            cards={ this.props.cards }
+            disablePopup={ this.props.spectating || !this.props.isMe }
+            hiddenTopCard
+            menu={ drawDeckMenu }
+            onCardClick={ this.props.onCardClick }
+            onCloseClick={ this.handleCloseClick.bind(this) }
+            onDragDrop={ this.props.onDragDrop }
+            onMouseOut={ this.props.onMouseOut }
+            onMouseOver={ this.props.onMouseOver }
+            popupLocation={ this.props.popupLocation }
+            popupMenu={ drawDeckPopupMenu }
+            size={ this.props.size }
+            source='draw deck'
+            title='Draw' />);
+
+        return this.renderDroppablePile('draw deck', drawDeck);
+    }
+}
+
+DrawDeck.propTypes = {
+    cardCount: PropTypes.number,
+    cards: PropTypes.array,
+    isMe: PropTypes.bool,
+    onCardClick: PropTypes.func,
+    onDragDrop: PropTypes.func,
+    onDrawClick: PropTypes.func,
+    onMenuItemClick: PropTypes.func,
+    onMouseOut: PropTypes.func,
+    onMouseOver: PropTypes.func,
+    onShuffleClick: PropTypes.func,
+    popupLocation: PropTypes.oneOf(['top', 'bottom']),
+    showDrawDeck: PropTypes.bool,
+    size: PropTypes.string,
+    spectating: PropTypes.bool
+};
+
+export default DrawDeck;

--- a/Components/GameBoard/DrawDeck.jsx
+++ b/Components/GameBoard/DrawDeck.jsx
@@ -50,9 +50,9 @@ class DrawDeck extends React.Component {
             { text: 'Shuffle', handler: this.handleShuffleClick }
         ] : null;
 
-        let drawDeckPopupMenu = [
+        let drawDeckPopupMenu = this.props.showDeck ? [
             { text: 'Close and Shuffle', handler: this.handleShuffleClick }
-        ];
+        ] : null;
 
         let drawDeck = (<CardPile className='draw'
             cardCount={ this.props.cardCount }
@@ -87,6 +87,7 @@ DrawDeck.propTypes = {
     onPopupChange: PropTypes.func,
     onShuffleClick: PropTypes.func,
     popupLocation: PropTypes.oneOf(['top', 'bottom']),
+    showDeck: PropTypes.bool,
     size: PropTypes.string,
     spectating: PropTypes.bool
 };

--- a/Components/GameBoard/DrawDeck.jsx
+++ b/Components/GameBoard/DrawDeck.jsx
@@ -9,34 +9,23 @@ class DrawDeck extends React.Component {
         super();
 
         this.handlePileClick = this.handlePileClick.bind(this);
-        this.handleShuffleClick = this.handleShuffleClick.bind(this);
         this.handleShowDeckClick = this.handleShowDeckClick.bind(this);
-        this.handleCloseClick = this.handleCloseClick.bind(this);
-        this.handleCloseAndShuffleClick = this.handleCloseAndShuffleClick.bind(this);
+        this.handleShuffleClick = this.handleShuffleClick.bind(this);
+        this.handlePopupChange = this.handlePopupChange.bind(this);
 
         this.state = {
             showDrawMenu: false
         };
     }
 
-    handleCloseClick() {
-        if(this.props.onDrawClick) {
-            this.props.onDrawClick();
-        }
-    }
-
-    handleCloseAndShuffleClick() {
-        if(this.props.onDrawClick) {
-            this.props.onDrawClick();
-        }
-
-        if(this.props.onShuffleClick) {
-            this.props.onShuffleClick();
-        }
-    }
-
     handlePileClick() {
         this.setState({ showDrawMenu: !this.state.showDrawMenu });
+    }
+
+    handleShowDeckClick() {
+        if(this.props.onPopupChange) {
+            this.props.onPopupChange({ visible: true });
+        }
     }
 
     handleShuffleClick() {
@@ -45,9 +34,9 @@ class DrawDeck extends React.Component {
         }
     }
 
-    handleShowDeckClick() {
-        if(this.props.onDrawClick) {
-            this.props.onDrawClick();
+    handlePopupChange(event) {
+        if(this.props.onPopupChange && !event.visible) {
+            this.props.onPopupChange({ visible: false });
         }
     }
 
@@ -62,7 +51,7 @@ class DrawDeck extends React.Component {
         ] : null;
 
         let drawDeckPopupMenu = [
-            { text: 'Close and Shuffle', handler: this.handleCloseAndShuffleClick }
+            { text: 'Close and Shuffle', handler: this.handleShuffleClick }
         ];
 
         let drawDeck = (<CardPile className='draw'
@@ -72,10 +61,10 @@ class DrawDeck extends React.Component {
             hiddenTopCard
             menu={ drawDeckMenu }
             onCardClick={ this.props.onCardClick }
-            onCloseClick={ this.handleCloseClick.bind(this) }
             onDragDrop={ this.props.onDragDrop }
             onMouseOut={ this.props.onMouseOut }
             onMouseOver={ this.props.onMouseOver }
+            onPopupChange={ this.handlePopupChange }
             popupLocation={ this.props.popupLocation }
             popupMenu={ drawDeckPopupMenu }
             size={ this.props.size }
@@ -92,13 +81,12 @@ DrawDeck.propTypes = {
     isMe: PropTypes.bool,
     onCardClick: PropTypes.func,
     onDragDrop: PropTypes.func,
-    onDrawClick: PropTypes.func,
     onMenuItemClick: PropTypes.func,
     onMouseOut: PropTypes.func,
     onMouseOver: PropTypes.func,
+    onPopupChange: PropTypes.func,
     onShuffleClick: PropTypes.func,
     popupLocation: PropTypes.oneOf(['top', 'bottom']),
-    showDrawDeck: PropTypes.bool,
     size: PropTypes.string,
     spectating: PropTypes.bool
 };

--- a/Components/GameBoard/DrawDeck.jsx
+++ b/Components/GameBoard/DrawDeck.jsx
@@ -54,10 +54,12 @@ class DrawDeck extends React.Component {
             { text: 'Close and Shuffle', handler: this.handleShuffleClick }
         ] : null;
 
+        let hasCards = !!this.props.cards && this.props.cards.length !== 0;
+
         let drawDeck = (<CardPile className='draw'
             cardCount={ this.props.cardCount }
             cards={ this.props.cards }
-            disablePopup={ this.props.spectating || !this.props.isMe }
+            disablePopup={ !hasCards && (this.props.spectating || !this.props.isMe) }
             hiddenTopCard
             menu={ drawDeckMenu }
             onCardClick={ this.props.onCardClick }

--- a/Components/GameBoard/GameBoard.jsx
+++ b/Components/GameBoard/GameBoard.jsx
@@ -49,7 +49,7 @@ export class GameBoard extends React.Component {
         this.onMouseOut = this.onMouseOut.bind(this);
         this.onMouseOver = this.onMouseOver.bind(this);
         this.onCardClick = this.onCardClick.bind(this);
-        this.onDrawClick = this.onDrawClick.bind(this);
+        this.handleDrawPopupChange = this.handleDrawPopupChange.bind(this);
         this.onDragDrop = this.onDragDrop.bind(this);
         this.onCommand = this.onCommand.bind(this);
         this.onConcedeClick = this.onConcedeClick.bind(this);
@@ -62,7 +62,6 @@ export class GameBoard extends React.Component {
 
         this.state = {
             cardToZoom: undefined,
-            showDrawDeck: false,
             spectating: true,
             showActionWindowsMenu: false,
             showCardMenu: {},
@@ -197,10 +196,8 @@ export class GameBoard extends React.Component {
         this.props.sendGameMessage('cardClicked', card.uuid);
     }
 
-    onDrawClick() {
-        this.props.sendGameMessage('showDrawDeck');
-
-        this.setState({ showDrawDeck: !this.state.showDrawDeck });
+    handleDrawPopupChange(event) {
+        this.props.sendGameMessage('showDrawDeck', event.visible);
     }
 
     sendChatMessage(message) {
@@ -389,10 +386,9 @@ export class GameBoard extends React.Component {
                         onMouseOver={ this.onMouseOver }
                         onMouseOut={ this.onMouseOut }
                         numDrawCards={ thisPlayer.numDrawCards }
-                        onDrawClick={ this.onDrawClick }
+                        onDrawPopupChange={ this.handleDrawPopupChange }
                         onShuffleClick={ this.onShuffleClick }
                         outOfGamePile={ thisPlayer.cardPiles.outOfGamePile }
-                        showDrawDeck={ this.state.showDrawDeck }
                         drawDeck={ thisPlayer.cardPiles.drawDeck }
                         onDragDrop={ this.onDragDrop }
                         discardPile={ thisPlayer.cardPiles.discardPile }

--- a/Components/GameBoard/GameBoard.jsx
+++ b/Components/GameBoard/GameBoard.jsx
@@ -324,6 +324,7 @@ export class GameBoard extends React.Component {
                         numDrawCards={ otherPlayer.numDrawCards }
                         discardPile={ otherPlayer.cardPiles.discardPile }
                         deadPile={ otherPlayer.cardPiles.deadPile }
+                        drawDeck={ otherPlayer.cardPiles.drawDeck }
                         onCardClick={ this.onCardClick }
                         onMouseOver={ this.onMouseOver }
                         onMouseOut={ this.onMouseOut }

--- a/Components/GameBoard/GameBoard.jsx
+++ b/Components/GameBoard/GameBoard.jsx
@@ -394,6 +394,7 @@ export class GameBoard extends React.Component {
                         discardPile={ thisPlayer.cardPiles.discardPile }
                         deadPile={ thisPlayer.cardPiles.deadPile }
                         shadows={ thisPlayer.cardPiles.shadows }
+                        showDeck={ thisPlayer.showDeck }
                         spectating={ this.state.spectating }
                         title={ thisPlayer.title }
                         onMenuItemClick={ this.onMenuItemClick }

--- a/Components/GameBoard/PlayerRow.jsx
+++ b/Components/GameBoard/PlayerRow.jsx
@@ -142,6 +142,7 @@ class PlayerRow extends React.Component {
             numDrawCards={ this.props.numDrawCards }
             onPopupChange={ this.props.onDrawPopupChange }
             onShuffleClick={ this.props.onShuffleClick }
+            showDeck={ this.props.showDeck }
             spectating={ this.props.spectating }
             { ...cardPileProps } />);
         let discardPile = (<CardPile className='discard' title='Discard' source='discard pile' cards={ this.props.discardPile }
@@ -207,6 +208,7 @@ PlayerRow.propTypes = {
     plotDeck: PropTypes.array,
     power: PropTypes.number,
     shadows: PropTypes.array,
+    showDeck: PropTypes.bool,
     side: PropTypes.oneOf(['top', 'bottom']),
     spectating: PropTypes.bool,
     title: PropTypes.object,

--- a/Components/GameBoard/PlayerRow.jsx
+++ b/Components/GameBoard/PlayerRow.jsx
@@ -140,7 +140,7 @@ class PlayerRow extends React.Component {
             cards={ this.props.drawDeck }
             isMe={ this.props.isMe }
             numDrawCards={ this.props.numDrawCards }
-            onDrawClick={ this.props.onDrawClick }
+            onPopupChange={ this.props.onDrawPopupChange }
             onShuffleClick={ this.props.onShuffleClick }
             spectating={ this.props.spectating }
             { ...cardPileProps } />);
@@ -198,7 +198,7 @@ PlayerRow.propTypes = {
     numDrawCards: PropTypes.number,
     onCardClick: PropTypes.func,
     onDragDrop: PropTypes.func,
-    onDrawClick: PropTypes.func,
+    onDrawPopupChange: PropTypes.func,
     onMenuItemClick: PropTypes.func,
     onMouseOut: PropTypes.func,
     onMouseOver: PropTypes.func,
@@ -207,7 +207,6 @@ PlayerRow.propTypes = {
     plotDeck: PropTypes.array,
     power: PropTypes.number,
     shadows: PropTypes.array,
-    showDrawDeck: PropTypes.bool,
     side: PropTypes.oneOf(['top', 'bottom']),
     spectating: PropTypes.bool,
     title: PropTypes.object,

--- a/Components/GameBoard/PlayerRow.jsx
+++ b/Components/GameBoard/PlayerRow.jsx
@@ -4,55 +4,10 @@ import classNames from 'classnames';
 
 import CardPile from './CardPile';
 import SquishableCardPanel from './SquishableCardPanel';
+import DrawDeck from './DrawDeck';
 import Droppable from './Droppable';
 
 class PlayerRow extends React.Component {
-    constructor() {
-        super();
-
-        this.onDrawClick = this.onDrawClick.bind(this);
-        this.onShuffleClick = this.onShuffleClick.bind(this);
-        this.onShowDeckClick = this.onShowDeckClick.bind(this);
-        this.onCloseClick = this.onCloseClick.bind(this);
-        this.onCloseAndShuffleClick = this.onCloseAndShuffleClick.bind(this);
-
-        this.state = {
-            showDrawMenu: false
-        };
-    }
-
-    onCloseClick() {
-        if(this.props.onDrawClick) {
-            this.props.onDrawClick();
-        }
-    }
-
-    onCloseAndShuffleClick() {
-        if(this.props.onDrawClick) {
-            this.props.onDrawClick();
-        }
-
-        if(this.props.onShuffleClick) {
-            this.props.onShuffleClick();
-        }
-    }
-
-    onDrawClick() {
-        this.setState({ showDrawMenu: !this.state.showDrawMenu });
-    }
-
-    onShuffleClick() {
-        if(this.props.onShuffleClick) {
-            this.props.onShuffleClick();
-        }
-    }
-
-    onShowDeckClick() {
-        if(this.props.onDrawClick) {
-            this.props.onDrawClick();
-        }
-    }
-
     getOutOfGamePile() {
         let pile = this.props.outOfGamePile;
 
@@ -158,15 +113,6 @@ class PlayerRow extends React.Component {
     }
 
     render() {
-        let drawDeckMenu = this.props.isMe && !this.props.spectating ? [
-            { text: 'Show', handler: this.onShowDeckClick, showPopup: true },
-            { text: 'Shuffle', handler: this.onShuffleClick }
-        ] : null;
-
-        let drawDeckPopupMenu = [
-            { text: 'Close and Shuffle', handler: this.onCloseAndShuffleClick }
-        ];
-
         let cardPileProps = {
             onCardClick: this.props.onCardClick,
             onDragDrop: this.props.onDragDrop,
@@ -189,10 +135,14 @@ class PlayerRow extends React.Component {
             source='hand'
             title='Hand'
             cardSize={ this.props.cardSize } />);
-        let drawDeck = (<CardPile className='draw' title='Draw' source='draw deck' cards={ this.props.drawDeck }
-            disablePopup={ this.props.spectating || !this.props.isMe }
-            menu={ drawDeckMenu } hiddenTopCard cardCount={ this.props.numDrawCards } popupMenu={ drawDeckPopupMenu }
-            onCloseClick={ this.onCloseClick.bind(this) }
+        let drawDeck = (<DrawDeck
+            cardCount={ this.props.numDrawCards }
+            cards={ this.props.drawDeck }
+            isMe={ this.props.isMe }
+            numDrawCards={ this.props.numDrawCards }
+            onDrawClick={ this.props.onDrawClick }
+            onShuffleClick={ this.props.onShuffleClick }
+            spectating={ this.props.spectating }
             { ...cardPileProps } />);
         let discardPile = (<CardPile className='discard' title='Discard' source='discard pile' cards={ this.props.discardPile }
             { ...cardPileProps } />);


### PR DESCRIPTION
**Requires throneteki/throneteki#2182**

Most of what this does is allow card select prompts to properly popup the draw deck during search abilities. It works around issues of the client and server "show deck" state becoming out of sync by sending the current client state for the draw deck popup to the server when appropriate.

### Full deck search:
![screen shot 2018-09-01 at 9 17 29 pm](https://user-images.githubusercontent.com/145077/44952145-7c2e4000-ae2c-11e8-8aa3-691d54aedd47.png)

### Top X card search:
![screen shot 2018-09-01 at 8 49 56 pm](https://user-images.githubusercontent.com/145077/44952146-89e3c580-ae2c-11e8-8d32-d0b4fe04d6cf.png)

### Exchange of Information (progression):
![screen shot 2018-09-01 at 8 50 26 pm](https://user-images.githubusercontent.com/145077/44952148-96681e00-ae2c-11e8-8f01-937762115d25.png)
![screen shot 2018-09-01 at 8 50 35 pm](https://user-images.githubusercontent.com/145077/44952150-9b2cd200-ae2c-11e8-9c82-0c062b61af80.png)
![screen shot 2018-09-01 at 8 50 48 pm](https://user-images.githubusercontent.com/145077/44952151-9e27c280-ae2c-11e8-9d99-07ed9060752a.png)


Resolves #11 