### PR TITLE
Enable hover based on whether card code is present

### DIFF
--- a/Components/GameBoard/PlayerRow.jsx
+++ b/Components/GameBoard/PlayerRow.jsx
@@ -126,7 +126,6 @@ class PlayerRow extends React.Component {
             cards={ this.props.hand }
             className='panel hand'
             groupVisibleCards
-            isMe={ this.props.isMe }
             username={ this.props.username }
             maxCards={ 5 }
             onCardClick={ this.props.onCardClick }
@@ -154,7 +153,6 @@ class PlayerRow extends React.Component {
             cards={ this.props.shadows }
             cardSize={ this.props.cardSize }
             className='panel shadows'
-            isMe={ this.props.isMe }
             maxCards={ 2 }
             onCardClick={ this.props.onCardClick }
             onMouseOut={ this.props.onMouseOut }

--- a/Components/GameBoard/SquishableCardPanel.jsx
+++ b/Components/GameBoard/SquishableCardPanel.jsx
@@ -5,14 +5,6 @@ import classNames from 'classnames';
 import Card from './Card';
 
 class SquishableCardPanel extends React.Component {
-    disableMouseOver(card) {
-        if(!card.facedown) {
-            return false;
-        }
-
-        return !this.props.isMe;
-    }
-
     getCards(needsSquish) {
         let overallDimensions = this.getOverallDimensions();
         let dimensions = this.getCardDimensions();
@@ -26,7 +18,7 @@ class SquishableCardPanel extends React.Component {
         let overflow = requiredWidth - overallDimensions.width;
         let offset = overflow / (handLength - 1);
 
-        if(!this.props.isMe && this.props.groupVisibleCards) {
+        if(this.props.groupVisibleCards && this.hasMixOfVisibleCards()) {
             cards = [...this.props.cards].sort((a, b) => a.facedown && !b.facedown ? -1 : 1);
         }
 
@@ -42,7 +34,7 @@ class SquishableCardPanel extends React.Component {
 
             return (<Card key={ card.uuid }
                 card={ card }
-                disableMouseOver={ this.disableMouseOver(card) }
+                disableMouseOver={ !card.code }
                 onClick={ this.props.onCardClick }
                 onMouseOver={ this.props.onMouseOver }
                 onMouseOut={ this.props.onMouseOut }
@@ -52,6 +44,10 @@ class SquishableCardPanel extends React.Component {
         });
 
         return hand;
+    }
+
+    hasMixOfVisibleCards() {
+        return this.props.cards.some(card => !!card.code) && this.props.cards.some(card => !card.code);
     }
 
     getCardDimensions() {
@@ -118,7 +114,6 @@ SquishableCardPanel.propTypes = {
     cards: PropTypes.array,
     className: PropTypes.string,
     groupVisibleCards: PropTypes.bool,
-    isMe: PropTypes.bool,
     maxCards: PropTypes.number,
     onCardClick: PropTypes.func,
     onMouseOut: PropTypes.func,


### PR DESCRIPTION
Previously, squishable card panels handled card hover using the `isMe`
property. Meereen creates a squishable card panel but does not have
access to the property, and was thus not allowing the controller to look
at the cards underneath.

Now, card hover is controlled by the presence of the card code. The
server will not send the card code unless it has already determined that
the player can see the card. Thus we no longer need to rely on the
`isMe` property for such visibility.

Fixes throneteki/throneteki#2298