### PR TITLE
Allow players to look at the top of their deck

### DIFF
--- a/Components/GameBoard/CardPile.jsx
+++ b/Components/GameBoard/CardPile.jsx
@@ -79,7 +79,9 @@ class CardPile extends React.Component {
             menuItem.handler();
         }
 
-        this.togglePopup();
+        if(menuItem.close) {
+            this.togglePopup();
+        }
     }
 
     onTopCardClick() {
@@ -159,9 +161,18 @@ class CardPile extends React.Component {
         let innerClass = classNames('inner', this.props.size);
         let linkIndex = 0;
 
-        let popupMenu = this.props.popupMenu ? (<div>{ this.props.popupMenu.map(menuItem => {
-            return <a className='btn btn-default' key={ linkIndex++ } onClick={ () => this.onPopupMenuItemClick(menuItem) }>{ menuItem.text }</a>;
-        }) }</div>) : null;
+        let popupMenu = this.props.popupMenu && (
+            <div className='card-pile-buttons'>
+                { this.props.popupMenu.map(menuItem => {
+                    return (
+                        <a className='btn btn-default' key={ linkIndex++ } onClick={ () => this.onPopupMenuItemClick(menuItem) }>
+                            { menuItem.icon && <span className={ `glyphicon glyphicon-${menuItem.icon}` }/> }
+                            { ' ' }
+                            { menuItem.text }
+                        </a>);
+                }) }
+            </div>
+        );
 
         popup = (
             <MovablePanel title={ this.props.title } name={ this.props.source } onCloseClick={ this.onCloseClick } side={ this.props.popupLocation }>

--- a/Components/GameBoard/DrawDeck.jsx
+++ b/Components/GameBoard/DrawDeck.jsx
@@ -8,18 +8,9 @@ class DrawDeck extends React.Component {
     constructor() {
         super();
 
-        this.handlePileClick = this.handlePileClick.bind(this);
         this.handleShowDeckClick = this.handleShowDeckClick.bind(this);
         this.handleShuffleClick = this.handleShuffleClick.bind(this);
         this.handlePopupChange = this.handlePopupChange.bind(this);
-
-        this.state = {
-            showDrawMenu: false
-        };
-    }
-
-    handlePileClick() {
-        this.setState({ showDrawMenu: !this.state.showDrawMenu });
     }
 
     handleShowDeckClick() {
@@ -45,30 +36,22 @@ class DrawDeck extends React.Component {
     }
 
     render() {
-        let drawDeckMenu = this.props.isMe && !this.props.spectating ? [
-            { text: 'Show', handler: this.handleShowDeckClick, showPopup: true },
-            { text: 'Shuffle', handler: this.handleShuffleClick }
-        ] : null;
+        let drawDeckPopupMenu = [];
 
-        let drawDeckPopupMenu = this.props.showDeck ? [
-            { text: 'Close and Shuffle', handler: this.handleShuffleClick }
-        ] : null;
+        if(this.props.isMe) {
+            if(!this.props.showDeck) {
+                drawDeckPopupMenu.push({ text: 'View Hidden', icon: 'eye-open', handler: this.handleShowDeckClick });
+            }
+            drawDeckPopupMenu.push({ text: 'Close and Shuffle', icon: 'random', handler: this.handleShuffleClick, close: true });
+        }
 
-        let hasCards = !!this.props.cards && this.props.cards.length !== 0;
-
-        // If we have more than 0 cards, but were not sent an array of card
-        // objects, no cards in the deck are currently visible. Thus, we want to
-        // display a facedown card in its place. If we were sent card objects,
-        // at least one card is visible, likely due to a search or reveal
-        // effect, and therefore use the visibility of those cards directly.
-        let usePlaceholderCard = this.props.cardCount > 0 && !this.props.cards;
+        let hasVisibleCards = !!this.props.cards && this.props.cards.some(card => !card.facedown);
 
         let drawDeck = (<CardPile className='draw'
             cardCount={ this.props.cardCount }
             cards={ this.props.cards }
-            disablePopup={ !hasCards && (this.props.spectating || !this.props.isMe) }
-            hiddenTopCard={ usePlaceholderCard }
-            menu={ drawDeckMenu }
+            disablePopup={ !hasVisibleCards && (this.props.spectating || !this.props.isMe) }
+            hiddenTopCard={ !this.props.revealTopCard }
             onCardClick={ this.props.onCardClick }
             onDragDrop={ this.props.onDragDrop }
             onMouseOut={ this.props.onMouseOut }
@@ -96,6 +79,7 @@ DrawDeck.propTypes = {
     onPopupChange: PropTypes.func,
     onShuffleClick: PropTypes.func,
     popupLocation: PropTypes.oneOf(['top', 'bottom']),
+    revealTopCard: PropTypes.bool,
     showDeck: PropTypes.bool,
     size: PropTypes.string,
     spectating: PropTypes.bool

--- a/Components/GameBoard/GameBoard.jsx
+++ b/Components/GameBoard/GameBoard.jsx
@@ -330,6 +330,7 @@ export class GameBoard extends React.Component {
                         onMouseOut={ this.onMouseOut }
                         outOfGamePile={ otherPlayer.cardPiles.outOfGamePile }
                         username={ this.props.user.username }
+                        revealTopCard={ otherPlayer.revealTopCard }
                         shadows={ otherPlayer.cardPiles.shadows }
                         spectating={ this.state.spectating }
                         title={ otherPlayer.title }
@@ -395,6 +396,7 @@ export class GameBoard extends React.Component {
                         onDragDrop={ this.onDragDrop }
                         discardPile={ thisPlayer.cardPiles.discardPile }
                         deadPile={ thisPlayer.cardPiles.deadPile }
+                        revealTopCard= { thisPlayer.revealTopCard }
                         shadows={ thisPlayer.cardPiles.shadows }
                         showDeck={ thisPlayer.showDeck }
                         spectating={ this.state.spectating }

--- a/Components/GameBoard/PlayerRow.jsx
+++ b/Components/GameBoard/PlayerRow.jsx
@@ -141,6 +141,7 @@ class PlayerRow extends React.Component {
             numDrawCards={ this.props.numDrawCards }
             onPopupChange={ this.props.onDrawPopupChange }
             onShuffleClick={ this.props.onShuffleClick }
+            revealTopCard={ this.props.revealTopCard }
             showDeck={ this.props.showDeck }
             spectating={ this.props.spectating }
             { ...cardPileProps } />);
@@ -205,6 +206,7 @@ PlayerRow.propTypes = {
     outOfGamePile: PropTypes.array,
     plotDeck: PropTypes.array,
     power: PropTypes.number,
+    revealTopCard: PropTypes.bool,
     shadows: PropTypes.array,
     showDeck: PropTypes.bool,
     side: PropTypes.oneOf(['top', 'bottom']),

--- a/less/gameboard.less
+++ b/less/gameboard.less
@@ -103,6 +103,15 @@
   }
 }
 
+.card-pile-buttons {
+  display: flex;
+
+  a {
+    flex: 1;
+    margin: 8px;
+  }
+}
+
 .player-home-row .card-pile.horizontal {
     margin-bottom: auto;
     margin-top: auto;


### PR DESCRIPTION
Changes how the draw deck behaves on the front end to allow players to
look at the top of their deck for Maester Gormon, without it looking
like the top card is revealed. Instead of a menu to open the draw deck,
it works like any other pile, but all cards are facedown by default.
Cards like Stolen Message now explicitly send data to reveal the top
card of the deck.

![Screen Shot 2019-06-18 at 9 31 32 PM](https://user-images.githubusercontent.com/145077/59736932-88935600-9210-11e9-8825-caed454e7c22.png)
