### PR TITLE
Scope token styling better

### DIFF
--- a/Components/GameBoard/Card.jsx
+++ b/Components/GameBoard/Card.jsx
@@ -119,15 +119,15 @@ class InnerCard extends React.Component {
             }
 
             for(const icon of card.iconsAdded || []) {
-                counters.push({ name: 'challenge-icon-token', icon: icon, count: 0, cancel: false });
+                counters.push({ name: 'challenge-icon', icon: icon, count: 0, cancel: false });
             }
 
             for(const icon of card.iconsRemoved || []) {
-                counters.push({ name: 'challenge-icon-token', icon: icon, count: 0, cancel: true });
+                counters.push({ name: 'challenge-icon', icon: icon, count: 0, cancel: true });
             }
 
             for(const item of card.factionStatus || []) {
-                counters.push({ name: 'faction-token', icon: item.faction, count: 0, cancel: item.status === 'lost' });
+                counters.push({ name: 'faction', icon: item.faction, count: 0, cancel: item.status === 'lost' });
             }
         }
 

--- a/Components/GameBoard/Counter.jsx
+++ b/Components/GameBoard/Counter.jsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 class Counter extends React.Component {
     render() {
-        let className = classNames('counter', this.props.name, {
+        let className = classNames('counter', `${this.props.name}-token`, {
             'cancel': this.props.cancel,
             'fade-out': this.props.fade
         });

--- a/less/cards.less
+++ b/less/cards.less
@@ -358,80 +358,68 @@
   background-color: rgba(0, 0, 0, 0.85);
 }
 
-.dupe {
+.dupe-token {
   background-color: @dupe-color;
 }
 
-.attachment-dupe {
-  background-color: fade(@dupe-color, 50%);
-}
-
-.card-power {
+.card-power-token {
   background-color: @power-color;
 }
 
-.attachment-power {
-  background-color: fade(@power-color, 50%);
-}
-
-.strength {
+.strength-token {
   background-color: @strength-color;
 }
 
-.count {
+.count-token {
   background-color: rgba(128,128,128,0.85);
 }
 
-.stand {
+.stand-token {
   background-color: rgba(128,128,128,0.85);
 }
 
-.poison {
+.poison-token {
   background-color: rgba(43,43, 0, 0.85);
 }
 
-.gold {
+.gold-token {
     background-color: rgba(255, 215, 0, 0.85);
 }
 
-.valarmorghulis {
+.valarmorghulis-token {
   background-color: rgba(192, 192, 192, 0.85);
 }
 
-.betrayal {
+.betrayal-token {
   background-color: rgba(153, 77, 0, 0.85);
 }
 
-.vengeance {
+.vengeance-token {
   background-color: rgba(87, 17, 124, 0.85);
 }
 
-.ear {
+.ear-token {
   background-color: rgba(162, 255, 81, 0.85);
 }
 
-.kiss {
+.kiss-token {
   background-color: rgba(127, 0, 255, 0.85);
 }
 
-.bell {
+.bell-token {
   background-color: rgba(103, 105, 45, 0.85);
 }
 
-.venom {
+.venom-token {
   background-color: @venom-color;
 }
 
-.blood {
+.blood-token {
     background-color: rgba(128, 0, 0, 0.85);
 }
 
-.shadow {
+.shadow-token {
     background-color: rgba(128, 0, 128, 0.85);
-}
-
-.attachment-venom {
-  background-color: fade(@venom-color, 50%);
 }
 
 .plot-selected {


### PR DESCRIPTION
When the shadow token was added, its purple color was inappropriately
applied to card preview. Now the token color styling is suffixed with
`-token`.

Also removes the unused attachment-specific tokens that were removed
some time ago in favor of a `fade` modifier.