### PR TITLE
fix the display of the time left for games with a time limit > 1 hour

### DIFF
--- a/Components/GameBoard/TimeLimitClock.jsx
+++ b/Components/GameBoard/TimeLimitClock.jsx
@@ -24,8 +24,14 @@ class TimeLimitClock extends React.Component {
         if(props.timeLimitStarted && !this.state.timer) {
             let timer = setInterval(() => {
                 let endTime = moment(this.props.timeLimitStartedAt).add(this.props.timeLimit, 'minutes');
-                let time = moment.utc(endTime.diff(moment())).format('mm:ss');
-                this.setState({ timeLeft: time });
+                let time = moment.utc(endTime.diff(moment()));
+                let timeDisplay = undefined;
+                if(time.hours() > 0) {
+                    timeDisplay = time.format('HH:mm:ss');
+                } else {
+                    timeDisplay = time.format('mm:ss');
+                }
+                this.setState({ timeLeft: timeDisplay });
             }, 1000);
 
             this.setState({ timer: timer });


### PR DESCRIPTION
if the time remaining is greater than 1 hour, only the minutes and seconds of the current hour will be displayed, leading to a confusing display of the remaining time. Now the time left will be displayed with a leading hour in case more than 1 hour is left