### PR TITLE
removes [B] from card name, in addition to [J] and [M].

### DIFF
--- a/Components/Decks/DeckEditor.jsx
+++ b/Components/Decks/DeckEditor.jsx
@@ -323,8 +323,8 @@ class DeckEditor extends React.Component {
 
         let count = parseInt(match[1]);
         let cardName = match[2].trim().toLowerCase();
-        //remove [J] and [M] restricted list indicators in a card name when the list is copied from thronesdb, trim at the end to remove the space between cardname and []
-        cardName = cardName.replace('[j]','').replace('[m]','').trim();
+        //remove [J] and [M] restricted list, and [B] banned list indicators in a card name when the list is copied from thronesdb, trim at the end to remove the space between cardname and []
+        cardName = cardName.replace(/\[(b|j|m)\]/g,'').trim();
         let packName = match[4] && match[4].trim().toLowerCase();
         let pack = packName && this.props.packs.find(pack => pack.code.toLowerCase() === packName || pack.name.toLowerCase() === packName);
 


### PR DESCRIPTION
ThronesDB also suffixes "banned" card with a `[B]`. let's get rid of that during import as well.

follows #90 
refs #89 