### PR TITLE
Allow events to be select during game creation

### DIFF
--- a/Components/Games/Game.js
+++ b/Components/Games/Game.js
@@ -47,6 +47,8 @@ function Game(props) {
 
     let formattedTime = moment.utc(timeDifference).format('HH:mm');
 
+    const title = game.event.name ? `${game.name} - ${game.event.name}` : game.name;
+
     return (<div key={ game.id }>
         <hr />
         <div className={ rowClass }>
@@ -55,7 +57,7 @@ function Game(props) {
                     ({ game.gameType })
                 </span>
                 <span className='game-title'>
-                    <b>{ game.name }</b>
+                    <b>{ title }</b>
                 </span>
                 <span className='game-time'>{ `[${formattedTime}]` }</span>
                 <span className='game-icons'>

--- a/Components/Games/PendingGame.jsx
+++ b/Components/Games/PendingGame.jsx
@@ -36,6 +36,7 @@ class PendingGame extends React.Component {
     }
 
     componentDidMount() {
+        this.props.setCurrentRestrictedList(this.props.currentGame.restrictedList);
         this.props.loadDecks();
         this.props.loadStandaloneDecks();
     }
@@ -74,6 +75,10 @@ class PendingGame extends React.Component {
 
     componentDidUpdate() {
         $(this.refs.messagePanel).scrollTop(999999);
+    }
+
+    componentWillUnmount() {
+        this.props.setCurrentRestrictedList(null);
     }
 
     isGameReady() {
@@ -273,6 +278,7 @@ PendingGame.propTypes = {
     loading: PropTypes.bool,
     navigate: PropTypes.func,
     sendSocketMessage: PropTypes.func,
+    setCurrentRestrictedList: PropTypes.func,
     socket: PropTypes.object,
     standaloneDecks: PropTypes.array,
     startGame: PropTypes.func,

--- a/Components/Games/PendingGame.jsx
+++ b/Components/Games/PendingGame.jsx
@@ -217,13 +217,16 @@ class PendingGame extends React.Component {
             return <div>You must be logged in to play, redirecting...</div>;
         }
 
+        const { currentGame } = this.props;
+        const title = currentGame.event.name ? `${currentGame.name} - ${currentGame.event.name}` : currentGame.name;
+
         return (
             <div>
                 <audio ref={ ref => this.notification = ref }>
                     <source src='/sound/charge.mp3' type='audio/mpeg' />
                     <source src='/sound/charge.ogg' type='audio/ogg' />
                 </audio>
-                <Panel title={ this.props.currentGame.name }>
+                <Panel title={ title }>
                     <div className='btn-group'>
                         <button className='btn btn-primary' disabled={ !this.isGameReady() || this.props.connecting || this.state.waiting } onClick={ this.onStartClick }>Start</button>
                         <button className='btn btn-primary' onClick={ this.onLeaveClick }>Leave</button>

--- a/ReduxActions/cards.js
+++ b/ReduxActions/cards.js
@@ -52,3 +52,10 @@ export function loadStandaloneDecks() {
         skipAuth: true
     };
 }
+
+export function setCurrentRestrictedList(currentRestrictedList) {
+    return {
+        type: 'SET_CURRENT_RESTRICTED_LIST',
+        currentRestrictedList
+    };
+}

--- a/pages/EventsAdmin/index.js
+++ b/pages/EventsAdmin/index.js
@@ -33,7 +33,7 @@ class EventsAdmin extends React.Component {
         return (
             <div className='col-xs-12'>
                 <Panel title='Events administration'>
-                    <a className='btn btn-primary' href='/events/add'>Add event</a>
+                    <a className='btn btn-primary' onClick={ () => navigate('/events/add') }>Add event</a>
                     <table className='table table-striped'>
                         <thead>
                             <tr>

--- a/reducers/cards.js
+++ b/reducers/cards.js
@@ -26,8 +26,6 @@ function processDeck(deck, state) {
     let formattedDeck = formatDeckAsFullCards(deck, state);
     const restrictedLists = state.currentRestrictedList ? [state.currentRestrictedList] : state.restrictedList;
 
-    console.log({ restrictedLists });
-
     if(!restrictedLists) {
         formattedDeck.status = {};
     } else {

--- a/reducers/cards.js
+++ b/reducers/cards.js
@@ -24,11 +24,14 @@ function processDeck(deck, state) {
     }
 
     let formattedDeck = formatDeckAsFullCards(deck, state);
+    const restrictedLists = state.currentRestrictedList ? [state.currentRestrictedList] : state.restrictedList;
 
-    if(!state.restrictedList) {
+    console.log({ restrictedLists });
+
+    if(!restrictedLists) {
         formattedDeck.status = {};
     } else {
-        formattedDeck.status = validateDeck(formattedDeck, { packs: state.packs, restrictedLists: state.restrictedList });
+        formattedDeck.status = validateDeck(formattedDeck, { packs: state.packs, restrictedLists });
     }
 
     return formattedDeck;
@@ -85,6 +88,15 @@ export default function(state = { decks: [] }, action) {
             });
 
             // In case the restricted list is received after the decks, updated the decks now
+            newState.decks = processDecks(newState.decks, newState);
+
+            return newState;
+        case 'SET_CURRENT_RESTRICTED_LIST':
+            newState = Object.assign({}, state, {
+                currentRestrictedList: action.currentRestrictedList
+            });
+
+            // Force an update to the validation results
             newState.decks = processDecks(newState.decks, newState);
 
             return newState;


### PR DESCRIPTION
Event drop down ("None" is the default option, does not appear if no events are active):
<img width="622" alt="Screen Shot 2020-04-19 at 12 04 24 AM" src="https://user-images.githubusercontent.com/145077/79681946-4392d400-81d3-11ea-93d4-9701d1ec569e.png">

Adds the event name in the title automatically to help distinguish:
<img width="678" alt="Screen Shot 2020-04-19 at 12 04 37 AM" src="https://user-images.githubusercontent.com/145077/79681950-468dc480-81d3-11ea-854b-b2dcd31a5963.png">

Only validates against the restricted list associated with the event on deck selection:
<img width="621" alt="Screen Shot 2020-04-19 at 12 05 32 AM" src="https://user-images.githubusercontent.com/145077/79681953-48f01e80-81d3-11ea-8813-1b9c4ad50dca.png">
