### PR TITLE
make the event´s name a prefix to the game´s name instead of a suffix

### DIFF
--- a/Components/Games/Game.js
+++ b/Components/Games/Game.js
@@ -47,7 +47,7 @@ function Game(props) {
 
     let formattedTime = moment.utc(timeDifference).format('HH:mm');
 
-    const title = game.event.name ? `${game.name} - ${game.event.name}` : game.name;
+    const title = game.event.name ? `${game.event.name} - ${game.name}` : game.name;
 
     return (<div key={ game.id }>
         <hr />

--- a/Components/Games/PendingGame.jsx
+++ b/Components/Games/PendingGame.jsx
@@ -218,7 +218,7 @@ class PendingGame extends React.Component {
         }
 
         const { currentGame } = this.props;
-        const title = currentGame.event.name ? `${currentGame.name} - ${currentGame.event.name}` : currentGame.name;
+        const title = currentGame.event.name ? `${currentGame.event.name} - ${currentGame.name}` : currentGame.name;
 
         return (
             <div>


### PR DESCRIPTION
As we discussed in the original PR, in my opinion the display of an event´s name is better placed at the front of a game´s name instead of at the back.