### PR TITLE
add option to use the default RL for an event

### DIFF
--- a/Components/Form/Input.jsx
+++ b/Components/Form/Input.jsx
@@ -9,6 +9,7 @@ class Input extends React.Component {
                 <div className={ this.props.fieldClass }>
                     <input name={ this.props.name } type={ this.props.type } className='form-control' id={ this.props.name }
                         placeholder={ this.props.placeholder } value={ this.props.value } onChange={ this.props.onChange } onBlur={ this.props.onBlur }
+                        checked={ this.props.checked }
                         { ...this.props.validationAttributes } />
                     <span className='text-danger' data-valmsg-replace='true' data-valmsg-for={ this.props.name } />
                 </div>
@@ -30,6 +31,7 @@ class Input extends React.Component {
 
 Input.displayName = 'Input';
 Input.propTypes = {
+    checked: PropTypes.bool,
     children: PropTypes.object,
     fieldClass: PropTypes.string,
     label: PropTypes.string,
@@ -39,7 +41,7 @@ Input.propTypes = {
     onBlur: PropTypes.func,
     onChange: PropTypes.func,
     placeholder: PropTypes.string,
-    type: PropTypes.oneOf(['text', 'password']),
+    type: PropTypes.oneOf(['text', 'password', 'checkbox']),
     validationAttributes: PropTypes.object,
     value: PropTypes.string
 };

--- a/pages/EventsAdmin/EventEditor.jsx
+++ b/pages/EventsAdmin/EventEditor.jsx
@@ -10,10 +10,11 @@ class EventEditor extends React.Component {
     constructor(props) {
         super(props);
 
-        const event = props.event || { restricted: [], banned: [] };
+        const event = props.event || { useDefaultRestrictedList: false, restricted: [], banned: [] };
         this.state = {
             eventId: event._id,
             name: event.name,
+            useDefaultRestrictedList: event.useDefaultRestrictedList,
             restricted: event.restricted,
             banned: event.banned,
             restrictedListText: this.formatListText(props.cards, event.restricted),
@@ -25,6 +26,7 @@ class EventEditor extends React.Component {
         return {
             _id: this.state.eventId,
             name: this.state.name,
+            useDefaultRestrictedList: this.state.useDefaultRestrictedList,
             restricted: this.state.restricted,
             banned: this.state.banned
         };
@@ -52,6 +54,14 @@ class EventEditor extends React.Component {
         let state = this.state;
 
         state[field] = event.target.value;
+
+        this.setState({ state });
+    }
+
+    onCheckboxChange(field, event) {
+        let state = this.state;
+
+        state[field] = event.target.checked;
 
         this.setState({ state });
     }
@@ -159,7 +169,8 @@ class EventEditor extends React.Component {
                 <form className='form form-horizontal'>
                     <Input name='name' label='Event Name' labelClass='col-sm-3' fieldClass='col-sm-9' placeholder='Event Name'
                         type='text' onChange={ this.onChange.bind(this, 'name') } value={ this.state.name } />
-
+                    <Input name='name' label='Use default Restricted List' labelClass='col-sm-3' fieldClass='col-sm-9'
+                        type='checkbox' onChange={ this.onCheckboxChange.bind(this, 'useDefaultRestrictedList') } checked={ this.state.useDefaultRestrictedList } />
                     <Typeahead label='Card' labelClass={ 'col-sm-3 col-xs-2' } fieldClass='col-sm-4 col-xs-5' labelKey={ 'label' } options={ allCards }
                         onChange={ this.addCardChange.bind(this) }>
                         <div className='col-xs-1 no-x-padding'>


### PR DESCRIPTION
Adds an option to events so that events can use the default restricted list instead of specifying their own
client changes, also see https://github.com/throneteki/throneteki/pull/3029