### PR TITLE
Handle ThronesDB markers after the pack name

### DIFF
--- a/Components/Decks/DeckParser.js
+++ b/Components/Decks/DeckParser.js
@@ -1,0 +1,40 @@
+export function lookupCardByName({ cardName, cards, packs }) {
+    const pattern = /^([^()[\]]+)(\s+\((.+)\))?(\s+\[.+\])?$/;
+
+    const match = cardName.trim().match(pattern);
+
+    if(!match) {
+        return;
+    }
+
+    const shortName = match[1].trim().toLowerCase();
+    let packName = match[3] && match[3].trim().toLowerCase();
+    let pack = packName && packs.find(pack => pack.code.toLowerCase() === packName || pack.name.toLowerCase() === packName);
+
+    let matchingCards = cards.filter(card => {
+        if(pack) {
+            return pack.code === card.packCode && card.name.toLowerCase() === shortName;
+        }
+
+        return card.name.toLowerCase() === shortName;
+    });
+
+    matchingCards.sort((a, b) => compareCardByReleaseDate(a, b, packs));
+
+    return matchingCards[0];
+}
+
+function compareCardByReleaseDate(a, b, packs) {
+    let packA = packs.find(pack => pack.code === a.packCode);
+    let packB = packs.find(pack => pack.code === b.packCode);
+
+    if(!packA.releaseDate && packB.releaseDate) {
+        return 1;
+    }
+
+    if(!packB.releaseDate && packA.releaseDate) {
+        return -1;
+    }
+
+    return new Date(packA.releaseDate) < new Date(packB.releaseDate) ? -1 : 1;
+}

--- a/Components/Decks/DeckParser.test.js
+++ b/Components/Decks/DeckParser.test.js
@@ -1,0 +1,68 @@
+const { lookupCardByName } = require('./DeckParser');
+
+describe('#lookupCardName', () => {
+    let cards, packs;
+
+    const uniqueCard = { code: '1', name: 'Unique Card', packCode: 'P1' };
+    const newVersionWithName = { code: '2', name: 'Duplicate Card', packCode: 'P2' };
+    const originalVersionWithName = { code: '3', name: 'Duplicate Card', packCode: 'P1' };
+
+    beforeEach(() => {
+        cards = [
+            uniqueCard,
+            newVersionWithName,
+            originalVersionWithName
+        ];
+        packs = [
+            { name: 'Pack 2', code: 'P2', releaseDate: '2020-03-01' },
+            { name: 'Pack 1', code: 'P1', releaseDate: '2020-01-01' }
+        ];
+    });
+
+    test('returns empty if no card matches', () => {
+        const card = lookupCardByName({ cardName: 'Unknown Card', cards, packs });
+        expect(card).toBeUndefined();
+    });
+
+    test('returns the matching card', () => {
+        const card = lookupCardByName({ cardName: 'Unique Card', cards, packs });
+        expect(card).toBe(uniqueCard);
+    });
+
+    test('returns the matching card regardless of case', () => {
+        const card = lookupCardByName({ cardName: 'UnIqUe CaRd', cards, packs });
+        expect(card).toBe(uniqueCard);
+    });
+
+    test('strips out the bracket indicators from ThronesDB', () => {
+        let cardWithIndicator = lookupCardByName({ cardName: 'Unique Card [B]', cards, packs });
+        let cardWithMultipleIndicators = lookupCardByName({ cardName: 'Unique Card [B] [M] [J] [P4]', cards, packs });
+        let cardWithPackAndIndicator = lookupCardByName({ cardName: 'Unique Card (Pack 1) [P8]', cards, packs });
+
+        expect(cardWithIndicator).toBe(uniqueCard);
+        expect(cardWithMultipleIndicators).toBe(uniqueCard);
+        expect(cardWithPackAndIndicator).toBe(uniqueCard);
+    });
+
+    describe('when there are multiple copies of a card', () => {
+        test('returns the earliest one by release data', () => {
+            const card = lookupCardByName({ cardName: 'Duplicate Card', cards, packs });
+            expect(card).toBe(originalVersionWithName);
+        });
+
+        test('returns the specific version when pack name is specified', () => {
+            const card = lookupCardByName({ cardName: 'Duplicate Card  (Pack 2)', cards, packs });
+            expect(card).toBe(newVersionWithName);
+        });
+
+        test('returns the specific version when pack code is specified', () => {
+            const card = lookupCardByName({ cardName: 'Duplicate Card  (P2)', cards, packs });
+            expect(card).toBe(newVersionWithName);
+        });
+
+        test('returns the earliest version if a pack name is specified that does not exist', () => {
+            const card = lookupCardByName({ cardName: 'Duplicate Card (P123)', cards, packs });
+            expect(card).toBe(originalVersionWithName);
+        });
+    });
+});


### PR DESCRIPTION
Fixes #117 

* The previous parsing only supported the markers if there was
  no pack name. With the redesigned cards, a lot of the cards
  on the previous ban list are now legal, but they have a pack
  code.
* Adds explicit tests around the parsing of card names
* Drops support for placeholder cards for cards that begin with
  "Custom CARDTYPE - Card Name". It's doubtful anyone is using
  this mechanism anymore.