### PR TITLE
Add default restricted list for events

### DIFF
--- a/Components/Decks/RestrictedListDropdown.jsx
+++ b/Components/Decks/RestrictedListDropdown.jsx
@@ -12,7 +12,9 @@ class RestrictedListDropdown extends React.Component {
         const selectedName = event.target.value;
         const restrictedList = this.props.restrictedLists.find(rl => rl.name === selectedName);
         this.setState({ value: selectedName });
-        this.props.setCurrentRestrictedList(restrictedList);
+        if(this.props.setCurrentRestrictedList) {
+            this.props.setCurrentRestrictedList(restrictedList);
+        }
         if(this.props.onChange) {
             this.props.onChange(restrictedList);
         }

--- a/Components/Games/Game.js
+++ b/Components/Games/Game.js
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import moment from 'moment';
 
 import GamePlayer from './GamePlayer';
+import { createGameTitle } from './GameHelper';
 
 function Game(props) {
     let game = props.game;
@@ -47,7 +48,7 @@ function Game(props) {
 
     let formattedTime = moment.utc(timeDifference).format('HH:mm');
 
-    const title = game.event.name ? `${game.event.name} - ${game.name}` : game.name;
+    const title = createGameTitle(game.name, game.event.name, game.restrictedList.cardSet);
 
     return (<div key={ game.id }>
         <hr />

--- a/Components/Games/GameHelper.js
+++ b/Components/Games/GameHelper.js
@@ -1,0 +1,5 @@
+import { cardSetLabel } from '../Decks/DeckHelper';
+
+export function createGameTitle(gameName, eventName, cardSet) {
+    return eventName ? `${eventName} - ${gameName}` : `${cardSetLabel(cardSet)} - ${gameName}`;
+}

--- a/Components/Games/PendingGame.jsx
+++ b/Components/Games/PendingGame.jsx
@@ -9,6 +9,7 @@ import Avatar from '../Site/Avatar';
 import SelectDeckModal from './SelectDeckModal';
 import DeckStatus from '../Decks/DeckStatus';
 import { cardSetLabel } from '../Decks/DeckHelper';
+import { createGameTitle } from './GameHelper';
 import * as actions from '../../actions';
 
 class PendingGame extends React.Component {
@@ -219,7 +220,7 @@ class PendingGame extends React.Component {
         }
 
         const { currentGame } = this.props;
-        const title = currentGame.event.name ? `${currentGame.event.name} - ${currentGame.name}` : currentGame.name;
+        const title = createGameTitle(currentGame.name, currentGame.event.name, currentGame.restrictedList.cardSet);
 
         return (
             <div>

--- a/pages/EventsAdmin/EditEvent.jsx
+++ b/pages/EventsAdmin/EditEvent.jsx
@@ -19,9 +19,9 @@ class EditEvent extends React.Component {
     }
 
     render() {
-        const { apiState, cards, eventId, events, navigate, packs, saveEvent } = this.props;
+        const { apiState, cards, eventId, events, navigate, packs, saveEvent, restrictedLists } = this.props;
 
-        if(!cards || !packs || !events) {
+        if(!cards || !packs || !events || !restrictedLists) {
             return <div>Please wait while loading from the server...</div>;
         }
 
@@ -32,7 +32,8 @@ class EditEvent extends React.Component {
                 event: events.find(event => event._id === eventId),
                 navigate,
                 packs,
-                onEventSave: saveEvent
+                onEventSave: saveEvent,
+                restrictedLists: restrictedLists
             } } />
         );
     }
@@ -47,6 +48,7 @@ EditEvent.propTypes = {
     loadEventEditor: PropTypes.func,
     navigate: PropTypes.func,
     packs: PropTypes.array,
+    restrictedLists : PropTypes.array,
     saveEvent: PropTypes.func
 };
 
@@ -57,7 +59,8 @@ function mapStateToProps(state) {
         events: state.events.events,
         eventSaved: state.events.eventSaved,
         loading: state.api.loading,
-        packs: state.cards.packs
+        packs: state.cards.packs,
+        restrictedLists: state.cards.restrictedList
     };
 }
 

--- a/pages/EventsAdmin/EventEditor.jsx
+++ b/pages/EventsAdmin/EventEditor.jsx
@@ -6,6 +6,7 @@ import Checkbox from '../../Components/Form/Checkbox';
 import Typeahead from '../../Components/Form/Typeahead';
 import TextArea from '../../Components/Form/TextArea';
 import ApiStatus from '../../Components/Site/ApiStatus';
+import RestrictedListDropdown from '../../Components/Decks/RestrictedListDropdown';
 
 class EventEditor extends React.Component {
     constructor(props) {
@@ -14,6 +15,7 @@ class EventEditor extends React.Component {
         let event = {};
         event = Object.assign(event, {
             useDefaultRestrictedList: false,
+            defaultRestrictedList: undefined,
             useEventGameOptions: false, 
             eventGameOptions: {}, 
             restricted: [], 
@@ -25,6 +27,7 @@ class EventEditor extends React.Component {
             eventId: event._id,
             name: event.name,
             useDefaultRestrictedList: event.useDefaultRestrictedList,
+            defaultRestrictedList: event.defaultRestrictedList,
             restricted: event.restricted,
             banned: event.banned,
             restrictedListText: this.formatListTextForCards(props.cards, event.restricted),
@@ -42,6 +45,7 @@ class EventEditor extends React.Component {
             _id: this.state.eventId,
             name: this.state.name,
             useDefaultRestrictedList: this.state.useDefaultRestrictedList,
+            defaultRestrictedList: this.state.defaultRestrictedList,
             useEventGameOptions: this.state.useEventGameOptions,
             eventGameOptions: this.state.eventGameOptions,
             restricted: this.state.restricted,
@@ -105,6 +109,14 @@ class EventEditor extends React.Component {
         let state = this.state;
 
         state['eventGameOptions'][field] = event.target.checked;
+
+        this.setState({ state });
+    }
+
+    onDefaultRestrictedListChange(restrictedList) {
+        let state = this.state;
+
+        state.defaultRestrictedList = restrictedList.name;
 
         this.setState({ state });
     }
@@ -222,6 +234,14 @@ class EventEditor extends React.Component {
     render() {
         const allCards = Object.values(this.props.cards);
 
+        //filter restrictedLists to the official ones, as we do not want an event to use the RL of an event as its default RL
+        const restrictedListDropdown = (
+            <RestrictedListDropdown
+                currentRestrictedList={ this.props.restrictedLists.find(rl => rl.name === this.state.defaultRestrictedList) }
+                onChange={ (restrictedList) => this.onDefaultRestrictedListChange(restrictedList) }
+                restrictedLists={ this.props.restrictedLists.filter(rl => rl.official) } /> 
+        );
+
         return (
             <div>
                 <ApiStatus apiState={ this.props.apiState } successMessage='Deck saved successfully.' />
@@ -231,7 +251,12 @@ class EventEditor extends React.Component {
                         type='text' onChange={ this.onChange.bind(this, 'name') } value={ this.state.name } />
                     <Checkbox name='useDefaultRestrictedList' label='Use default Restricted List' labelClass='col-sm-4' fieldClass='col-sm-offset-3 col-sm-8'
                         onChange={ this.onCheckboxChange.bind(this, 'useDefaultRestrictedList') } checked={ this.state.useDefaultRestrictedList } />
-                    
+                    { this.state.useDefaultRestrictedList
+                    && <div className='form-group'>
+                        { restrictedListDropdown }
+                    </div>
+                    }
+
                     <div className='form-group'>
                         <label className='col-sm-3 col-xs-2 control-label'>Event Game Options</label>
                     </div>
@@ -324,7 +349,8 @@ EventEditor.propTypes = {
     event: PropTypes.object,
     navigate: PropTypes.func,
     onEventSave: PropTypes.func,
-    packs: PropTypes.array
+    packs: PropTypes.array,
+    restrictedLists: PropTypes.array
 };
 
 export default EventEditor;

--- a/pages/EventsAdmin/EventEditor.jsx
+++ b/pages/EventsAdmin/EventEditor.jsx
@@ -253,7 +253,9 @@ class EventEditor extends React.Component {
                         onChange={ this.onCheckboxChange.bind(this, 'useDefaultRestrictedList') } checked={ this.state.useDefaultRestrictedList } />
                     { this.state.useDefaultRestrictedList
                     && <div className='form-group'>
-                        { restrictedListDropdown }
+                        <div className='col-sm-offset-3'>
+                            { restrictedListDropdown }
+                        </div>
                     </div>
                     }
 


### PR DESCRIPTION
An event was able to choose to use it´s custom RL or the default RL. Now that there are two default RL´s to choose from, original and redesigns, an event needs to be able to choose which one of the default RL´s to use. This PR adds this option to an event.
Furthermore, the title of a game in the lobby is now modified to include the cardset that is used by the game so that playes can determine which game uses which cardset with ease in the lobby.

Please also have a look at the corresponding server PR