### PR TITLE
fix issues in the deckeditor with the new restricted list dropdown.

### DIFF
--- a/Components/Decks/DeckEditor.jsx
+++ b/Components/Decks/DeckEditor.jsx
@@ -363,7 +363,7 @@ class DeckEditor extends React.Component {
     }
 
     render() {
-        if(!this.props.factions || !this.props.agendas || !this.props.cards) {
+        if(!this.props.factions || !this.props.agendas || !this.props.cards || !this.props.restrictedList) {
             return <div>Please wait while loading from the server...</div>;
         }
 

--- a/Components/Decks/RestrictedListDropdown.jsx
+++ b/Components/Decks/RestrictedListDropdown.jsx
@@ -6,12 +6,25 @@ class RestrictedListDropdown extends React.Component {
         super(props);
 
         this.state = { value: props.currentRestrictedList && props.currentRestrictedList.name };
+        //if the currentRestrictedList is not set, update the restrictedList with the first RL in the list to set the initial state
+        //this solves the problem, that the display of the dropdown (showing a selected entry) doesn´t correspond to the state 
+        if(!props.currentRestrictedList) {
+            this.updateRestrictedList(props.restrictedLists[0].name);
+        }
     }
 
     handleChange(event) {
         const selectedName = event.target.value;
-        const restrictedList = this.props.restrictedLists.find(rl => rl.name === selectedName);
-        this.setState({ value: selectedName });
+        this.updateRestrictedList(selectedName);
+    }
+
+    updateRestrictedList(restrictedListName) {
+        this.setState({ value: restrictedListName });
+        let restrictedList = this.props.restrictedLists.find(rl => rl.name === restrictedListName);
+        //if the chosen restrictedList is an event and that event uses a default restricted list instead of a custom one, use the defaultRestrictedList instead
+        if(restrictedList.useDefaultRestrictedList && restrictedList.defaultRestrictedList) {
+            restrictedList = this.props.restrictedLists.find(rl => rl.name === restrictedList.defaultRestrictedList);
+        }
         if(this.props.setCurrentRestrictedList) {
             this.props.setCurrentRestrictedList(restrictedList);
         }

--- a/pages/Decks.jsx
+++ b/pages/Decks.jsx
@@ -44,7 +44,7 @@ class Decks extends React.Component {
             );
         }
 
-        if(this.props.apiLoading) {
+        if(this.props.apiLoading || !this.props.cards || !this.props.decks || !this.props.restrictedLists) {
             content = <div>Loading decks from the server...</div>;
         } else if(!this.props.apiSuccess) {
             content = <AlertPanel type='error' message={ this.props.apiMessage } />;

--- a/reducers/cards.js
+++ b/reducers/cards.js
@@ -24,7 +24,8 @@ function processDeck(deck, state) {
     }
 
     let formattedDeck = formatDeckAsFullCards(deck, state);
-    const restrictedLists = state.currentRestrictedList ? [state.currentRestrictedList] : state.restrictedList.slice(0, 1);
+    const fallbackRestrictedList = state.restrictedList ? state.restrictedList.slice(0, 1) : undefined;
+    const restrictedLists = state.currentRestrictedList ? [state.currentRestrictedList] : fallbackRestrictedList;
 
     if(!restrictedLists) {
         formattedDeck.status = {};


### PR DESCRIPTION
when the chosen restricted list is an event that uses a default restricted list, the deck should be validated against the default restricted list, not the custom rl of the event

this is a follow up to #120 