### PR TITLE
align the items in the plots-pane on the left/flex-start instead of the center

### DIFF
--- a/less/gameboard.less
+++ b/less/gameboard.less
@@ -251,7 +251,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
 }
 
 .plot-group {


### PR DESCRIPTION
this leads to the chess clock div not bouncing around when it switches its size during the transition of displaying text and image

resolves throneteki issue [#3038](https://github.com/throneteki/throneteki/issues/3038)