### PR TITLE
fix menu click on cards that are in a CardTiledList in a CardPile

### DIFF
--- a/Components/GameBoard/CardPile.jsx
+++ b/Components/GameBoard/CardPile.jsx
@@ -129,6 +129,7 @@ class CardPile extends React.Component {
             onCardMouseOut: this.props.onMouseOut,
             onCardMouseOver: this.props.onMouseOver,
             onTouchMove: this.props.onTouchMove,
+            onMenuItemClick: this.props.onMenuItemClick,
             size: this.props.size,
             source: this.props.source
         };

--- a/Components/GameBoard/CardTiledList.jsx
+++ b/Components/GameBoard/CardTiledList.jsx
@@ -13,6 +13,7 @@ function CardTiledList(props) {
             onMouseOut={ props.onCardMouseOut }
             onMouseOver={ props.onCardMouseOver }
             onTouchMove={ props.onTouchMove }
+            onMenuItemClick={ props.onMenuItemClick }
             orientation={ card.type === 'plot' ? 'horizontal' : 'vertical' }
             size={ props.size }
             source={ props.source } />);
@@ -37,6 +38,7 @@ CardTiledList.propTypes = {
     onCardClick: PropTypes.func,
     onCardMouseOut: PropTypes.func,
     onCardMouseOver: PropTypes.func,
+    onMenuItemClick: PropTypes.func,
     onTouchMove: PropTypes.func,
     size: PropTypes.string,
     source: PropTypes.string,


### PR DESCRIPTION
for example Banner Agendas under the Alliance Agenda should now be clickable
see Free Companies from the Forgotten Heroes pack