### PR TITLE
fix the deck selection for games that use an event but the event is not locking the decks

### DIFF
--- a/Components/Games/PendingGame.jsx
+++ b/Components/Games/PendingGame.jsx
@@ -210,7 +210,7 @@ class PendingGame extends React.Component {
     }
 
     isCurrentEventALockedDeckEvent() {
-        return this.props.currentGame.event && this.props.currentGame.event._id !== 'none'; //&& this.props.currentGame.event.lockedDecks;
+        return this.props.currentGame.event && this.props.currentGame.event._id !== 'none' && this.props.currentGame.event.lockDecks;
     }
 
     filterDecksForCurrentEvent() {


### PR DESCRIPTION
currently you can´t select a deck when you are in a game that uses an event but the event is not locking decks