### PR TITLE
Quick fix to card order numbers being hidden

### DIFF
--- a/Components/GameBoard/Card.jsx
+++ b/Components/GameBoard/Card.jsx
@@ -293,11 +293,11 @@ class InnerCard extends React.Component {
         let content = this.props.connectDragSource(
             <div className='card-frame'>
                 { this.getDragFrame(image) }
-                { this.getCardOrder() }
                 <div className={ cardClass }
                     onMouseOver={ this.props.disableMouseOver ? null : this.onMouseOver.bind(this, this.props.card) }
                     onMouseOut={ this.props.disableMouseOver ? null : this.onMouseOut }
                     onClick={ ev => this.onClick(ev, this.props.card) }>
+                    { this.getCardOrder() }
                     <div>
                         <span className='card-name'>{ this.props.card.name }</span>
                         { image }

--- a/less/cards.less
+++ b/less/cards.less
@@ -178,12 +178,12 @@
   font-size: 16px;
   font-weight: bold;
   height: 26px;
-  left: 50%;
+  left: 12px;
   line-height: 24px;
   margin: 0 0 0 -12px;
   position: absolute;
   text-align: center;
-  top: -28px;
+  top: 0px;
   width: 24px;
   z-index: @layer-card-menu;
 }


### PR DESCRIPTION
Just a quick fix to show card order numbers where they would usually be hidden. Currently it is being hidden due to the requirement for `overflow-x` on the player-rows to be scrollable (in case screen is too small or squashed). Due to this being scrollable, a bug (or some call it "feature") prevents `overflow-y: visible` from properly showing overflown divs, such as this ordered number deep within the card frame.

**Previously:**
![image](https://github.com/throneteki/throneteki-client/assets/23492047/1e269e02-615e-49ec-a6d5-561416594e5a)

**Now:**
![image](https://github.com/throneteki/throneteki-client/assets/23492047/c4f405e3-e7a5-4e57-a028-d3eb8c0c8a5d)

There's some really tricky ways that this could maybe be fixed whilst keeping the current look (eg. wrappers within wrappers, and fixing lots of the flex-related issues along the way), but it does not seem worth the time. This 5 minute fix is completely fine, and I'm sure people will be grateful they can see those numbers now. :)

**Should be pushed to live alongside this PR: https://github.com/throneteki/throneteki/pull/3436**