### PR TITLE
Updating notification permission by removing setter

### DIFF
--- a/Components/Games/GameLobby.jsx
+++ b/Components/Games/GameLobby.jsx
@@ -51,11 +51,7 @@ class GameLobby extends React.Component {
 
     componentDidMount() {
         if(window.Notification && Notification.permission !== 'granted') {
-            Notification.requestPermission((status) => {
-                if(Notification.permission !== status) {
-                    Notification.permission = status;
-                }
-            });
+            Notification.requestPermission();
         }
     }
 


### PR DESCRIPTION
Fixes THRONETEKI-2AN

Sentry Issue [here](https://throneteki.sentry.io/issues/679653452/?environment=production&project=123019&query=is%3Aunresolved&referrer=issue-stream&stream_index=1).

`permission` is readonly, and is automatically set by Notification API when user chooses. Not sure if this is outdated code or not, as I struggled to find version history online. Docs here: https://developer.mozilla.org/en-US/docs/Web/API/notification