### PR TITLE
Fixing undefined restricted lists on new game

### DIFF
--- a/Components/Games/NewGame.jsx
+++ b/Components/Games/NewGame.jsx
@@ -29,12 +29,10 @@ class NewGame extends React.Component {
         this.onChessClockTimeLimitChange = this.onChessClockTimeLimitChange.bind(this);
         this.onDelayToStartClockChange = this.onDelayToStartClockChange.bind(this);
 
-        const defaultRestrictedList = props.restrictedLists.filter(rl => rl.official)[0];
-
         this.state = {
-            selectedMode: `none:${defaultRestrictedList && defaultRestrictedList._id}`,
+            selectedMode: 'none:none',
             eventId: 'none',
-            restrictedListId: defaultRestrictedList && defaultRestrictedList._id,
+            restrictedListId: 'none',
             optionsLocked: false,
             spectators: true,
             showHand: false,


### PR DESCRIPTION
Should resolve the following sentry.io issue: https://throneteki.sentry.io/issues/2032528830/?project=123019&query=is%3Aunresolved&referrer=issue-stream&stream_index=6#

Seems this was missed when fixing new games to "Loading..." when events or RL are still being fetched. Code is outdated, as constructor can be created before restricted list is even fetched.

Tested with a 5 second delay on the restricted list retrieval (as shown below):
![msedge_FwDQL8TEJ0](https://github.com/throneteki/throneteki-client/assets/23492047/87307dc2-ef2a-49f0-bc77-4723d2f71b8c)