### PR TITLE
Adding launch & tasks to properly debug client within vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,38 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "msedge",
+            "request": "launch",
+            "name": "Launch Client (Edge)",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "env": {
+                "VERSION": "Local build"
+            },
+            "url": "http://localhost:8080",
+            "webRoot": "${workspaceFolder}",
+            "preLaunchTask": "start server",
+            "postDebugTask": "stop server"
+        },
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Launch Client (Chrome)",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "env": {
+                "VERSION": "Local build"
+            },
+            "url": "http://localhost:8080",
+            "webRoot": "${workspaceFolder}",
+            "preLaunchTask": "start server",
+            "postDebugTask": "stop server"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,39 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "start server",
+            "type": "npm",
+            "script": "start",
+            "isBackground": true,
+            "options": {
+                "env": {
+                    "VERSION": "Local build"
+                }
+            },
+            "problemMatcher": {
+                "pattern": {
+                    "regexp": "ˆ$"
+                },
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "Compiling...",
+                    "endsPattern": "Compiled .*"
+                }
+            }
+        },
+        {
+          "label": "stop server",
+          "command": "echo ${input:terminate}",
+          "type": "shell"
+        }
+    ],
+    "inputs": [
+      {
+        "id": "terminate",
+        "type": "command",
+        "command": "workbench.action.tasks.terminate",
+        "args": "terminateAll"
+      }
+    ]
+}


### PR DESCRIPTION
As title states, adds a VS Code debugger for edge & chrome:
![image](https://github.com/throneteki/throneteki-client/assets/23492047/1b70c5b5-deaa-4b7b-8a20-059f9ed5ab89)
